### PR TITLE
Allow to pass data when stream is opened

### DIFF
--- a/src/__tests__/bored-mplex.test.ts
+++ b/src/__tests__/bored-mplex.test.ts
@@ -7,20 +7,28 @@ describe("BoredMplex", () => {
   const sleep = (amount: number) => new Promise((resolve) => setTimeout(resolve, amount));
 
   describe("onStream", () => {
-    it ("calls onStream on open", async () => {
-      let streamOpened = false;
+    it ("calls onStream on open", (done) => {
       const mplex = new BoredMplex(() => {
-        streamOpened = true;
+        done();
       });
 
       mplex.write(pack({
         id: "foo",
         type: "open"
       }));
+    });
 
-      await sleep(10);
+    it ("passes data from open to onStream", (done) => {
+      const mplex = new BoredMplex((stream, data) => {
+        expect(data?.toString()).toEqual("this-is-data");
+        done();
+      });
 
-      expect(streamOpened).toBeTruthy();
+      mplex.write(pack({
+        id: "foo",
+        type: "open",
+        data: Buffer.from("this-is-data")
+      }));
     });
 
     it ("does not call onStream without open", async () => {

--- a/src/bored-mplex.ts
+++ b/src/bored-mplex.ts
@@ -9,7 +9,7 @@ export class BoredMplex extends Transform {
   private pingInterval?: NodeJS.Timeout;
   private pingTimeout?: NodeJS.Timeout;
 
-  constructor(private onStream?: (stream: Stream) => void, opts?: TransformOptions) {
+  constructor(private onStream?: (stream: Stream, data?: Buffer) => void, opts?: TransformOptions) {
     super(opts);
 
     this.on("error", () => {
@@ -81,7 +81,7 @@ export class BoredMplex extends Transform {
     }
 
     if (!stream && msg.type === "open") {
-      stream = this.createStream(msg.id);
+      stream = this.createStream(msg.id, msg.data);
 
       return callback();
     }
@@ -109,11 +109,11 @@ export class BoredMplex extends Transform {
     callback();
   }
 
-  protected createStream(id: number): Stream {
+  protected createStream(id: number, data?: Buffer): Stream {
     const stream = new Stream(id, this);
 
     this.streams.set(id, stream);
-    this.onStream?.(stream);
+    this.onStream?.(stream, data);
 
     return stream;
   }


### PR DESCRIPTION
Allows client to add metadata about stream (like destination information etc).