### PR TITLE
Use stream fair queuing using deficit round robin

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "typescript": "^4.2.3"
   },
   "dependencies": {
+    "@divine/synchronization": "^1.2.1",
     "msgpackr": "1.2.9"
   }
 }

--- a/src/__tests__/bored-mplex-client.test.ts
+++ b/src/__tests__/bored-mplex-client.test.ts
@@ -4,10 +4,19 @@ import { PassThrough } from "stream";
 import { StreamMessage } from "../types";
 
 describe("BoredMplexClient", () => {
+  let mplex: BoredMplexClient;
+
+  beforeEach(() => {
+    mplex = new BoredMplexClient();
+  });
+
+  afterEach(() => {
+    mplex.end();
+  });
+
   it("transforms chunks", (done) => {
     const incoming = new PassThrough();
     const outgoing = new PassThrough();
-    const mplex = new BoredMplexClient();
     const stream = mplex.openStream();
 
     mplex.pipe(outgoing);
@@ -28,8 +37,6 @@ describe("BoredMplexClient", () => {
 
   describe("openStream", () => {
     it("returns a stream with id", () => {
-      const mplex = new BoredMplexClient();
-
       expect(mplex.openStream().id).toEqual(1);
       expect(mplex.openStream().id).toEqual(2);
     });

--- a/src/__tests__/bored-mplex.test.ts
+++ b/src/__tests__/bored-mplex.test.ts
@@ -9,6 +9,7 @@ describe("BoredMplex", () => {
   describe("onStream", () => {
     it ("calls onStream on open", (done) => {
       const mplex = new BoredMplex(() => {
+        mplex.end();
         done();
       });
 
@@ -21,6 +22,7 @@ describe("BoredMplex", () => {
     it ("passes data from open to onStream", (done) => {
       const mplex = new BoredMplex((stream, data) => {
         expect(data?.toString()).toEqual("this-is-data");
+        mplex.end();
         done();
       });
 
@@ -45,6 +47,7 @@ describe("BoredMplex", () => {
       await sleep(10);
 
       expect(streamOpened).toBeFalsy();
+      mplex.end();
     });
   });
 
@@ -72,6 +75,7 @@ describe("BoredMplex", () => {
       await sleep(10);
 
       expect(streamData).toEqual(["hello", "world"]);
+      mplex.end();
     });
 
     it ("passes data from stream", async () => {
@@ -114,6 +118,7 @@ describe("BoredMplex", () => {
     it("emits stream end from close message", (done) => {
       const mplex = new BoredMplex((stream) => {
         stream.on("finish", () => {
+          mplex.end();
           done();
         });
       });
@@ -147,6 +152,7 @@ describe("BoredMplex", () => {
         const msg = unpack(chunk);
 
         if (msg.type === "pong") {
+          mplex.end();
           done();
         }
       });
@@ -162,6 +168,7 @@ describe("BoredMplex", () => {
       const mplex = new BoredMplex();
 
       mplex.on("pong", () => {
+        mplex.end();
         done();
       });
       mplex.write(pack({
@@ -175,6 +182,7 @@ describe("BoredMplex", () => {
 
       mplex.enableKeepAlive(1000);
       mplex.on("timeout", () => {
+        mplex.end();
         done();
       });
       jest.advanceTimersByTime(5000);
@@ -189,6 +197,7 @@ describe("BoredMplex", () => {
       passthrough.on("error", (err) => err);
       passthrough.end();
       mplex.on("timeout", () => {
+        mplex.end();
         done();
       });
       jest.advanceTimersByTime(5000);

--- a/src/bored-mplex.ts
+++ b/src/bored-mplex.ts
@@ -6,7 +6,7 @@ import { StreamMessage } from "./types";
 
 export class BoredMplex extends Transform {
   public streams: Map<number, Stream> = new Map();
-  public queue = new DRRQueue<Buffer>(16384);
+  public queue = new DRRQueue<Buffer>(this.writableHighWaterMark);
 
   private pingInterval?: NodeJS.Timeout;
   private pingTimeout?: NodeJS.Timeout;

--- a/src/bored-mplex.ts
+++ b/src/bored-mplex.ts
@@ -7,7 +7,6 @@ import { StreamMessage } from "./types";
 export class BoredMplex extends Transform {
   public streams: Map<number, Stream> = new Map();
   public queue = new DRRQueue<Buffer>(16384);
-  public rxQueue = new DRRQueue<Buffer>(16384);
 
   private pingInterval?: NodeJS.Timeout;
   private pingTimeout?: NodeJS.Timeout;
@@ -18,12 +17,10 @@ export class BoredMplex extends Transform {
     this.on("error", () => {
       this.streams.forEach((stream) => stream.end());
       this.queue = new DRRQueue<Buffer>();
-      this.rxQueue = new DRRQueue<Buffer>();
     });
     this.on("finish", () => {
       this.streams.forEach((stream) => stream.end());
       this.queue = new DRRQueue<Buffer>();
-      this.rxQueue = new DRRQueue<Buffer>();
     });
 
     this.processQueue();

--- a/src/bored-mplex.ts
+++ b/src/bored-mplex.ts
@@ -1,10 +1,13 @@
 import { Transform, TransformCallback, TransformOptions } from "stream";
 import { pack, unpack } from "msgpackr";
+import { DRRQueue } from "@divine/synchronization";
 import { Stream } from "./stream";
 import { StreamMessage } from "./types";
 
 export class BoredMplex extends Transform {
   public streams: Map<number, Stream> = new Map();
+  public queue = new DRRQueue<Buffer>(16384);
+  public rxQueue = new DRRQueue<Buffer>(16384);
 
   private pingInterval?: NodeJS.Timeout;
   private pingTimeout?: NodeJS.Timeout;
@@ -14,10 +17,43 @@ export class BoredMplex extends Transform {
 
     this.on("error", () => {
       this.streams.forEach((stream) => stream.end());
+      this.queue = new DRRQueue<Buffer>();
+      this.rxQueue = new DRRQueue<Buffer>();
     });
     this.on("finish", () => {
       this.streams.forEach((stream) => stream.end());
+      this.queue = new DRRQueue<Buffer>();
+      this.rxQueue = new DRRQueue<Buffer>();
     });
+
+    this.processQueue();
+  }
+
+  private processQueue() {
+    if (this.writableEnded) {
+      return;
+    }
+
+    const data = this.queue.shift();
+
+    if (data) {
+      const ok = this.push(data);
+
+      if (!ok) {
+        this.once("drain", () => {
+          this.processQueue();
+        });
+        
+        return;
+      }
+    }
+
+    setImmediate(() => this.processQueue());
+  }
+
+  _read(size: number) {
+    this.emit("drain");
+    super._read(size);
   }
 
   enableKeepAlive(interval = 10_000, timeout = 2_000) {
@@ -43,7 +79,6 @@ export class BoredMplex extends Transform {
     if (this.writableEnded) {
       return;
     }
-
     this.push(pack({
       id: 0,
       type: "ping"
@@ -54,7 +89,6 @@ export class BoredMplex extends Transform {
     if (this.writableEnded) {
       return;
     }
-
     this.push(pack({
       id: 0,
       type: "pong"

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,6 +303,14 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@divine/synchronization@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@divine/synchronization/-/synchronization-1.2.1.tgz#ae721bdeacaf398efd131bf41dd4cbc9ca18e4ce"
+  integrity sha512-ReWu1nv6qQFy6qZKUJPIacZ3vYs6c/RP/UYNi6yI+skIi8kFsYiveWyNhGTj8nJeNsik7zy6fZqvupqkOP7Mbg==
+  dependencies:
+    denque "^1.4.0"
+    tslib "^2.0.0"
+
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
@@ -1325,6 +1333,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+denque@^1.4.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.1.tgz#07f670e29c9a78f8faecb2566a1e2c11929c5cbf"
+  integrity sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -3824,6 +3837,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.17.1:
   version "3.21.0"


### PR DESCRIPTION
Fair queuing should guarantee enough resources for all multiplexed streams. Should fix issues with keepalive etc timeouts when some streams consume all network resources.

https://courses.cs.duke.edu/cps214/spring09/papers/drr.pdf