### PR TITLE
Fix backpressure propagation from Stream to BoredMplex

### DIFF
--- a/src/__tests__/bored-mplex.test.ts
+++ b/src/__tests__/bored-mplex.test.ts
@@ -181,7 +181,7 @@ describe("BoredMplex", () => {
       const mplex = new BoredMplex();
 
       mplex.enableKeepAlive(1000);
-      mplex.on("timeout", () => {
+      mplex.once("timeout", () => {
         mplex.end();
         done();
       });
@@ -196,11 +196,64 @@ describe("BoredMplex", () => {
       mplex.pipe(passthrough);
       passthrough.on("error", (err) => err);
       passthrough.end();
-      mplex.on("timeout", () => {
+      mplex.once("timeout", () => {
         mplex.end();
         done();
       });
       jest.advanceTimersByTime(5000);
+    });
+  });
+
+  describe("backpressure", () => {
+    it("pushToQueue returns false when queued bytes exceed high water mark", () => {
+      const mplex = new BoredMplex(undefined, { writableHighWaterMark: 100 });
+
+      // Prevent queue from draining by making shift return undefined
+      mplex.queue.shift = () => undefined;
+
+      // First push: 50 bytes, under threshold
+      expect(mplex.pushToQueue({ id: "1", data: Buffer.alloc(50), size: 50 })).toBe(true);
+
+      // Second push: 60 more bytes, total 110 exceeds 100 byte threshold
+      const result = mplex.pushToQueue({ id: "2", data: Buffer.alloc(60), size: 60 });
+
+      expect(result).toBe(false);
+      mplex.end();
+    });
+
+    it("pushToQueue returns true when queue has capacity", () => {
+      const mplex = new BoredMplex(undefined, { writableHighWaterMark: 1000 });
+
+      const result = mplex.pushToQueue({ id: "1", data: Buffer.alloc(10), size: 10 });
+
+      expect(result).toBe(true);
+      mplex.end();
+    });
+
+    it("stream write waits for drain when backpressure is active", (done) => {
+      const mplex = new BoredMplex(undefined, { writableHighWaterMark: 100 });
+
+      mplex.write(pack({ id: 1, type: "open" }));
+      const stream = mplex.streams.get(1)!;
+
+      // Fill queue beyond high water mark (500 bytes > 100 byte threshold)
+      for (let i = 0; i < 5; i++) {
+        mplex.pushToQueue({ id: `fill-${i}`, data: Buffer.alloc(100), size: 100 });
+      }
+
+      let callbackCalled = false;
+
+      stream.write(Buffer.from("test"), () => {
+        callbackCalled = true;
+        mplex.end();
+        done();
+      });
+
+      // Callback not called synchronously
+      expect(callbackCalled).toBe(false);
+
+      // Emit drain to trigger callback
+      mplex.emit("drain");
     });
   });
 });

--- a/src/bored-mplex.ts
+++ b/src/bored-mplex.ts
@@ -11,6 +11,7 @@ export class BoredMplex extends Transform {
   private pingInterval?: NodeJS.Timeout;
   private pingTimeout?: NodeJS.Timeout;
   private processPending = false;
+  private queuedBytes = 0;
 
   constructor(private onStream?: (stream: Stream, data?: Buffer) => void, opts?: TransformOptions) {
     super(opts);
@@ -18,17 +19,24 @@ export class BoredMplex extends Transform {
     this.on("error", () => {
       this.streams.forEach((stream) => stream.end());
       this.queue = new DRRQueue<Buffer>();
+      this.queuedBytes = 0;
     });
     this.on("finish", () => {
       this.streams.forEach((stream) => stream.end());
       this.queue = new DRRQueue<Buffer>();
+      this.queuedBytes = 0;
     });
   }
 
-  pushToQueue(data: DRRData<Buffer>) {
+  pushToQueue(data: DRRData<Buffer>): boolean {
     this.queue.push(data);
+    this.queuedBytes += data.size;
+
+    const hasCapacity = this.queuedBytes < this.writableHighWaterMark;
 
     this.process();
+
+    return hasCapacity;
   }
 
   private process() {
@@ -47,6 +55,7 @@ export class BoredMplex extends Transform {
     const data = this.queue.shift();
 
     if (data) {
+      this.queuedBytes -= data.byteLength;
       const ok = this.push(data);
 
       if (!ok) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -17,9 +17,9 @@ export class Stream extends Duplex {
     });
   }
 
-  private pushToSession(type: string, data?: Buffer) {
-    this.session.pushToQueue({
-      id: this.id.toString(), 
+  private pushToSession(type: string, data?: Buffer): boolean {
+    return this.session.pushToQueue({
+      id: this.id.toString(),
       data: pack({
         id: this.id,
         type,
@@ -40,7 +40,26 @@ export class Stream extends Duplex {
   public _write(chunk: any, encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
     if (this.session.writableEnded) return;
 
-    this.pushToSession("data", chunk);
+    const hasCapacity = this.pushToSession("data", chunk);
+
+    if (!hasCapacity) {
+      let called = false;
+      const onDrain = () => {
+        if (called) return;
+        called = true;
+        this.session.removeListener("finish", onFinish);
+        callback();
+      };
+      const onFinish = () => {
+        if (called) return;
+        called = true;
+        this.session.removeListener("drain", onDrain);
+        callback();
+      };
+      this.session.once("drain", onDrain);
+      this.session.once("finish", onFinish);
+      return;
+    }
 
     callback();
   }


### PR DESCRIPTION
## Summary

`Stream._write()` was calling `callback()` immediately after pushing data, regardless of whether the downstream `BoredMplex` had backpressure. This violates Node.js stream semantics - when a fast producer writes to a Stream, data queues unbounded in `BoredMplex.queue` without any flow control signal back to the producer.

**Changes:**
- `pushToQueue()` now returns boolean indicating queue capacity
- `Stream._write()` waits for `drain` event when backpressure is detected
- Handles `finish` event to prevent listener leaks when session ends during backpressure